### PR TITLE
Fixed null safety issue in icon

### DIFF
--- a/lib/flutter_dropdown.dart
+++ b/lib/flutter_dropdown.dart
@@ -17,7 +17,7 @@ class DropDown<T> extends StatefulWidget {
   final Widget? hint;
   final Function(T?)? onChanged;
   final bool isExpanded;
-  final Widget icon;
+  final Widget? icon;
 
   /// If need to clear dropdown currently selected value
   final bool isCleared;
@@ -78,7 +78,7 @@ class _DropDownState<T> extends State<DropDown<T>> {
               .map<DropdownMenuItem<T>>((item) => buildDropDownItem(item))
               .toList(),
           hint: widget.hint,
-          icon: icon ?? Icon(
+          icon: widget.icon ?? Icon(
             Icons.expand_more,
           ),
         );


### PR DESCRIPTION
Related Issue: #7

Previous Code::
icon initialization ` final Widget icon;`
icon usage `icon: icon ?? Icon(
            Icons.expand_more,
          ),`
according to this case icon is optional, so I updated icon as optional
initialization `final Widget? icon;`
icon usage `icon: widget.icon ?? Icon(
            Icons.expand_more,
          ),`
